### PR TITLE
Fix IRS structures materialized views

### DIFF
--- a/3-reveal/migrations/5-IRS/2-Zambia-2019/deploy/zambia_irs_export.psql
+++ b/3-reveal/migrations/5-IRS/2-Zambia-2019/deploy/zambia_irs_export.psql
@@ -107,6 +107,6 @@ CREATE INDEX IF NOT EXISTS zambia_irs_export_event_id_idx ON zambia_irs_export (
 
 CREATE INDEX IF NOT EXISTS zambia_irs_export_structure_jurisdiction_idx ON zambia_irs_export (structure_jurisdiction_id);
 
-CREATE UNIQUE INDEX IF NOT EXISTS zambia_irs_export_idx ON zambia_irs_export (structure_id);
+CREATE UNIQUE INDEX IF NOT EXISTS zambia_irs_export_idx ON zambia_irs_export (structure_id, task_id);
 
 COMMIT;

--- a/3-reveal/migrations/5-IRS/2-Zambia-2019/deploy/zambia_irs_structures.psql
+++ b/3-reveal/migrations/5-IRS/2-Zambia-2019/deploy/zambia_irs_structures.psql
@@ -15,7 +15,7 @@ SET search_path TO :"schema",public;
 
 CREATE MATERIALIZED VIEW IF NOT EXISTS zambia_irs_structures
 AS
-SELECT
+SELECT DISTINCT ON (locations.id, events_query.task_id)
     locations.id AS structure_id,
     locations.jurisdiction_id AS old_jurisdiction_id,
     zambia_structure_jurisdictions.jurisdiction_depth AS old_jurisdiction_depth,
@@ -132,6 +132,6 @@ CREATE INDEX IF NOT EXISTS zambia_irs_structures_old_jurisdiction_idx ON zambia_
 
 CREATE INDEX IF NOT EXISTS zambia_irs_structures_geom_gix ON zambia_irs_structures USING GIST (structure_geometry);
 
-CREATE UNIQUE INDEX IF NOT EXISTS zambia_irs_structures_idx ON zambia_irs_structures (structure_id);
+CREATE UNIQUE INDEX IF NOT EXISTS zambia_irs_structures_idx ON zambia_irs_structures (structure_id, task_id);
 
 COMMIT;

--- a/3-reveal/migrations/5-IRS/3-Namibia-2019/deploy/namibia_irs_export.psql
+++ b/3-reveal/migrations/5-IRS/3-Namibia-2019/deploy/namibia_irs_export.psql
@@ -89,6 +89,6 @@ CREATE INDEX IF NOT EXISTS namibia_irs_export_event_id_idx ON namibia_irs_export
 
 CREATE INDEX IF NOT EXISTS namibia_irs_export_structure_jurisdiction_idx ON namibia_irs_export (structure_jurisdiction_id);
 
-CREATE UNIQUE INDEX IF NOT EXISTS namibia_irs_export_idx ON namibia_irs_export (structure_id);
+CREATE UNIQUE INDEX IF NOT EXISTS namibia_irs_export_idx ON namibia_irs_export (structure_id, task_id);
 
 COMMIT;

--- a/3-reveal/migrations/5-IRS/3-Namibia-2019/deploy/namibia_irs_structures.psql
+++ b/3-reveal/migrations/5-IRS/3-Namibia-2019/deploy/namibia_irs_structures.psql
@@ -10,7 +10,7 @@ SET search_path TO :"schema",public;
 
 CREATE MATERIALIZED VIEW IF NOT EXISTS namibia_irs_structures
 AS
-SELECT
+SELECT DISTINCT ON (locations.id, events_query.task_id)
     locations.id AS structure_id,
     locations.jurisdiction_id AS structure_jurisdiction_id,
     locations.code AS structure_code,
@@ -104,7 +104,7 @@ LEFT JOIN LATERAL (
         ORDER BY task_id, event_date DESC
     ) AS subq
 ) AS events_query ON true
-ORDER BY events_query.event_date;
+WHERE locations.status != 'Inactive';
 
 CREATE INDEX IF NOT EXISTS namibia_irs_structures_structure_jurisdiction_idx ON namibia_irs_structures (structure_jurisdiction_id);
 
@@ -116,6 +116,6 @@ CREATE INDEX IF NOT EXISTS namibia_irs_structures_task_id_idx ON namibia_irs_str
 
 CREATE INDEX IF NOT EXISTS namibia_irs_structures_geom_gix ON namibia_irs_structures USING GIST (structure_geometry);
 
-CREATE UNIQUE INDEX IF NOT EXISTS namibia_irs_structures_idx ON namibia_irs_structures (structure_id);
+CREATE UNIQUE INDEX IF NOT EXISTS namibia_irs_structures_idx ON namibia_irs_structures (structure_id, task_id);
 
 COMMIT;


### PR DESCRIPTION
Change the queries such that the unique index is on the structure_id and task_id columns instead of just structure_id.  This is because it is possible to get multiple structure ids for different plans.

Fixes: https://github.com/onaio/reveal-frontend/issues/1198