### PR TITLE
Add id field to IRS structure views

### DIFF
--- a/3-reveal/migrations/5-IRS/2-Zambia-2019/deploy/zambia_irs_structures.psql
+++ b/3-reveal/migrations/5-IRS/2-Zambia-2019/deploy/zambia_irs_structures.psql
@@ -16,6 +16,9 @@ SET search_path TO :"schema",public;
 CREATE MATERIALIZED VIEW IF NOT EXISTS zambia_irs_structures
 AS
 SELECT DISTINCT ON (locations.id, events_query.task_id)
+    public.uuid_generate_v5(
+        '6ba7b810-9dad-11d1-80b4-00c04fd430c8',
+        concat(locations.id, events_query.task_id)) AS id,
     locations.id AS structure_id,
     locations.jurisdiction_id AS old_jurisdiction_id,
     zambia_structure_jurisdictions.jurisdiction_depth AS old_jurisdiction_depth,
@@ -132,6 +135,8 @@ CREATE INDEX IF NOT EXISTS zambia_irs_structures_old_jurisdiction_idx ON zambia_
 
 CREATE INDEX IF NOT EXISTS zambia_irs_structures_geom_gix ON zambia_irs_structures USING GIST (structure_geometry);
 
-CREATE UNIQUE INDEX IF NOT EXISTS zambia_irs_structures_idx ON zambia_irs_structures (structure_id, task_id);
+CREATE UNIQUE INDEX IF NOT EXISTS zambia_irs_structures_structure_task_idx ON zambia_irs_structures (structure_id, task_id);
+
+CREATE UNIQUE INDEX IF NOT EXISTS zambia_irs_structures_idx ON zambia_irs_structures (id);
 
 COMMIT;

--- a/3-reveal/migrations/5-IRS/2-Zambia-2019/verify/zambia_irs_structures.psql
+++ b/3-reveal/migrations/5-IRS/2-Zambia-2019/verify/zambia_irs_structures.psql
@@ -9,6 +9,7 @@ FROM pg_matviews
 WHERE matviewname = 'zambia_irs_structures';
 
 SELECT
+    id,
     structure_id,
     old_jurisdiction_id,
     old_jurisdiction_depth,
@@ -46,6 +47,14 @@ schemaname = :'schema'
 AND tablename = 'zambia_irs_structures'
 AND indexdef LIKE '%CREATE UNIQUE INDEX%'
 AND indexname = 'zambia_irs_structures_idx';
+
+SELECT 1/COUNT(*)
+FROM pg_catalog.pg_indexes
+WHERE
+schemaname = :'schema'
+AND tablename = 'zambia_irs_structures'
+AND indexdef LIKE '%CREATE UNIQUE INDEX%'
+AND indexname = 'zambia_irs_structures_structure_task_idx';
 
 SELECT 1/COUNT(*)
 FROM pg_catalog.pg_indexes

--- a/3-reveal/migrations/5-IRS/3-Namibia-2019/deploy/namibia_irs_structures.psql
+++ b/3-reveal/migrations/5-IRS/3-Namibia-2019/deploy/namibia_irs_structures.psql
@@ -11,6 +11,9 @@ SET search_path TO :"schema",public;
 CREATE MATERIALIZED VIEW IF NOT EXISTS namibia_irs_structures
 AS
 SELECT DISTINCT ON (locations.id, events_query.task_id)
+    public.uuid_generate_v5(
+        '6ba7b810-9dad-11d1-80b4-00c04fd430c8',
+        concat(locations.id, events_query.task_id)) AS id,
     locations.id AS structure_id,
     locations.jurisdiction_id AS structure_jurisdiction_id,
     locations.code AS structure_code,
@@ -72,9 +75,9 @@ LEFT JOIN LATERAL (
     FROM
     (
         SELECT
-            DISTINCT ON (events.task_id)
+            DISTINCT ON (tasks.identifier)
             events.id AS event_id,
-            events.task_id AS task_id,
+            tasks.identifier AS task_id,
             events.event_date AS event_date,
             tasks.plan_identifier AS plan_id,
             -- get fields from JSON --
@@ -95,12 +98,13 @@ LEFT JOIN LATERAL (
             COALESCE (events.form_data->'refusalReasonMop'->>0, '')::text AS refusalReasonMop,
             COALESCE (events.form_data->'business_status'->>0, 'Not Visited')::text AS business_status
             -- end get fields from JSON --
-        FROM events
-        LEFT JOIN tasks
+        FROM tasks
+        LEFT JOIN events
             ON tasks.identifier = events.task_id
-        WHERE locations.id = events.base_entity_id
-        AND events.entity_type = 'Structure'
-        AND events.event_type = 'Spray'
+            AND events.entity_type = 'Structure'
+            AND events.event_type = 'Spray'
+        WHERE locations.id = tasks.task_for
+        AND tasks.status != 'Cancelled'
         ORDER BY task_id, event_date DESC
     ) AS subq
 ) AS events_query ON true
@@ -116,6 +120,8 @@ CREATE INDEX IF NOT EXISTS namibia_irs_structures_task_id_idx ON namibia_irs_str
 
 CREATE INDEX IF NOT EXISTS namibia_irs_structures_geom_gix ON namibia_irs_structures USING GIST (structure_geometry);
 
-CREATE UNIQUE INDEX IF NOT EXISTS namibia_irs_structures_idx ON namibia_irs_structures (structure_id, task_id);
+CREATE UNIQUE INDEX IF NOT EXISTS namibia_irs_structures_structure_task_idx ON namibia_irs_structures (structure_id, task_id);
+
+CREATE UNIQUE INDEX IF NOT EXISTS namibia_irs_structures_idx ON namibia_irs_structures (id);
 
 COMMIT;

--- a/3-reveal/migrations/5-IRS/3-Namibia-2019/verify/namibia_irs_structures.psql
+++ b/3-reveal/migrations/5-IRS/3-Namibia-2019/verify/namibia_irs_structures.psql
@@ -9,6 +9,7 @@ FROM pg_matviews
 WHERE matviewname = 'namibia_irs_structures';
 
 SELECT
+    id,
     structure_id,
     structure_jurisdiction_id,
     structure_code,
@@ -50,6 +51,14 @@ schemaname = :'schema'
 AND tablename = 'namibia_irs_structures'
 AND indexdef LIKE '%CREATE UNIQUE INDEX%'
 AND indexname = 'namibia_irs_structures_idx';
+
+SELECT 1/COUNT(*)
+FROM pg_catalog.pg_indexes
+WHERE
+schemaname = :'schema'
+AND tablename = 'namibia_irs_structures'
+AND indexdef LIKE '%CREATE UNIQUE INDEX%'
+AND indexname = 'namibia_irs_structures_structure_task_idx';
 
 SELECT 1/COUNT(*)
 FROM pg_catalog.pg_indexes

--- a/3-reveal/superset/namibia_irs_structures_geojson_slice.sql
+++ b/3-reveal/superset/namibia_irs_structures_geojson_slice.sql
@@ -1,4 +1,5 @@
 SELECT
+    id,
     structure_id,
     structure_jurisdiction_id as jurisdiction_id,
     task_id,
@@ -11,6 +12,7 @@ SELECT
     ) AS geojson
 FROM (
     SELECT
+        id,
         structure_id,
         structure_jurisdiction_id,
         structure_code,


### PR DESCRIPTION
With multiple plans, the structure_id field is not guaranteed to be unique.  This PR adds a unique id field.  These reports require a unique field to work well in the web app.

Related PR: https://github.com/onaio/reveal-frontend/pull/1206