### PR TITLE
Beam pilot fixes round2

### DIFF
--- a/3-reveal/migrations/2-transaction_tables/deploy/rework_plan_sub_tables.psql
+++ b/3-reveal/migrations/2-transaction_tables/deploy/rework_plan_sub_tables.psql
@@ -1,0 +1,30 @@
+-- Deploy reveal_transaction_tables:rework_plan_sub_tables to pg
+-- requires: actions
+-- requires: goal_target
+-- requires: plan_jurisdiction
+
+BEGIN;
+
+SET search_path TO :"schema",public;
+
+-- remove FK to jurisdictions
+-- remove UNIQUE on jurisdiction id and plan id
+ALTER TABLE plan_jurisdiction
+DROP CONSTRAINT IF EXISTS fk_jurisdiction_plan_jurisdiction,
+DROP CONSTRAINT IF EXISTS plan_jurisdiction_jurisdiction_id_plan_id_key;
+
+-- remove UNIQUE on goal id and plan id
+ALTER TABLE goals
+DROP CONSTRAINT IF EXISTS goals_goal_id_plan_id_key;
+
+-- remove UNIQUE on goal id and plan id
+ALTER TABLE goal_target
+DROP CONSTRAINT IF EXISTS goal_target_goal_id_plan_id_key;
+
+-- Add goals indices
+CREATE INDEX IF NOT EXISTS goals_goal_id_plan_id_idx ON goals (goal_id, plan_id);
+
+-- Add goal_target indices
+CREATE INDEX IF NOT EXISTS goal_target_goal_id_plan_id_idx ON goal_target (goal_id, plan_id);
+
+COMMIT;

--- a/3-reveal/migrations/2-transaction_tables/revert/rework_plan_sub_tables.psql
+++ b/3-reveal/migrations/2-transaction_tables/revert/rework_plan_sub_tables.psql
@@ -1,0 +1,26 @@
+-- Revert reveal_transaction_tables:rework_plan_sub_tables from pg
+
+BEGIN;
+
+SET search_path TO :"schema",public;
+
+ALTER TABLE plan_jurisdiction
+ADD CONSTRAINT fk_jurisdiction_plan_jurisdiction
+    FOREIGN KEY (jurisdiction_id)
+    REFERENCES jurisdictions (code)
+    ON DELETE RESTRICT,
+ADD CONSTRAINT plan_jurisdiction_jurisdiction_id_plan_id_key
+    UNIQUE (jurisdiction_id, plan_id);
+
+ALTER TABLE goals
+ADD CONSTRAINT goals_goal_id_plan_id_key
+    UNIQUE (goal_id, plan_id);
+
+ALTER TABLE goal_target
+ADD CONSTRAINT goal_target_goal_id_plan_id_key
+    UNIQUE (goal_id, plan_id);
+
+DROP INDEX IF EXISTS goals_goal_id_plan_id_idx;
+DROP INDEX IF EXISTS goal_target_goal_id_plan_id_idx;
+
+COMMIT;

--- a/3-reveal/migrations/2-transaction_tables/sqitch.plan
+++ b/3-reveal/migrations/2-transaction_tables/sqitch.plan
@@ -18,3 +18,4 @@ nullable_client_residence [clients] 2020-08-27T16:04:12Z mosh <kjayanoris@ona.io
 location_status_indices [jurisdictions locations] 2020-08-27T17:52:14Z mosh <kjayanoris@ona.io> # Add location status indices.
 location_geo_ordering_indices [jurisdictions locations] 2020-09-01T12:08:22Z mosh <kjayanoris@ona.io> # Add location geo ordering indices.
 nullable_task_focus [tasks] 2020-09-01T12:13:14Z mosh <kjayanoris@ona.io> # Make task focus nullable.
+rework_plan_sub_tables [actions goal_target plan_jurisdiction] 2020-09-07T15:58:07Z mosh <kjayanoris@ona.io> # Rework plan sub tables.

--- a/3-reveal/migrations/2-transaction_tables/verify/goals.psql
+++ b/3-reveal/migrations/2-transaction_tables/verify/goals.psql
@@ -73,13 +73,6 @@ FROM pg_catalog.pg_indexes
 WHERE
 schemaname = :'schema'
 AND tablename = 'goals'
-AND indexname = 'goals_goal_id_plan_id_key';
-
-SELECT 1/COUNT(*)
-FROM pg_catalog.pg_indexes
-WHERE
-schemaname = :'schema'
-AND tablename = 'goals'
 AND indexname = 'goal_id_idx';
 
 ROLLBACK;

--- a/3-reveal/migrations/2-transaction_tables/verify/plan_jurisdiction.psql
+++ b/3-reveal/migrations/2-transaction_tables/verify/plan_jurisdiction.psql
@@ -23,27 +23,12 @@ AND 1 = ALL(conkey);
 SELECT 1/COUNT(*)
 FROM pg_catalog.pg_constraint
 WHERE
-conname = 'fk_jurisdiction_plan_jurisdiction'
-AND contype = 'f'
-AND 2 = ALL(conkey)
-AND 5 = ALL(confkey);
-
-SELECT 1/COUNT(*)
-FROM pg_catalog.pg_constraint
-WHERE
 conname = 'fk_plan_plan_jurisdiction'
 AND contype = 'f'
 AND 3 = ALL(conkey)
 AND 1 = ALL(confkey);
 
 -- check indices
-SELECT 1/COUNT(*)
-FROM pg_catalog.pg_indexes
-WHERE
-schemaname = :'schema'
-AND tablename = 'plan_jurisdiction'
-AND indexname = 'plan_jurisdiction_jurisdiction_id_plan_id_key';
-
 SELECT 1/COUNT(*)
 FROM pg_catalog.pg_indexes
 WHERE

--- a/3-reveal/migrations/2-transaction_tables/verify/rework_plan_sub_tables.psql
+++ b/3-reveal/migrations/2-transaction_tables/verify/rework_plan_sub_tables.psql
@@ -2,6 +2,68 @@
 
 BEGIN;
 
--- XXX Add verifications here.
+SET search_path TO :"schema",public;
+
+-- check dropped constraints
+SELECT 1/COUNT(*)
+FROM (
+    SELECT COUNT(*)
+    FROM pg_catalog.pg_constraint
+    WHERE
+    conname = 'fk_jurisdiction_plan_jurisdiction'
+    AND conrelid = CONCAT(:'schema', '.plan_jurisdiction')::regclass
+    AND contype = 'f'
+    AND 2 = ALL(conkey)
+    AND 5 = ALL(confkey)
+) AS foo
+WHERE count = 0;
+
+SELECT 1/COUNT(*)
+FROM (
+    SELECT COUNT(*)
+    FROM pg_catalog.pg_indexes
+    WHERE
+    schemaname = :'schema'
+    AND tablename = 'plan_jurisdiction'
+    AND indexname = 'plan_jurisdiction_jurisdiction_id_plan_id_key'
+) AS foo
+WHERE count = 0;
+
+SELECT 1/COUNT(*)
+FROM (
+    SELECT COUNT(*)
+    FROM pg_catalog.pg_indexes
+    WHERE
+    schemaname = :'schema'
+    AND tablename = 'goals'
+    AND indexname = 'goals_goal_id_plan_id_key'
+) AS foo
+WHERE count = 0;
+
+SELECT 1/COUNT(*)
+FROM (
+    SELECT COUNT(*)
+    FROM pg_catalog.pg_indexes
+    WHERE
+    schemaname = :'schema'
+    AND tablename = 'goal_target'
+    AND indexname = 'goal_target_goal_id_plan_id_key'
+) AS foo
+WHERE count = 0;
+
+-- check new indices
+SELECT 1/COUNT(*)
+FROM pg_catalog.pg_indexes
+WHERE
+schemaname = :'schema'
+AND tablename = 'goals'
+AND indexname = 'goals_goal_id_plan_id_idx';
+
+SELECT 1/COUNT(*)
+FROM pg_catalog.pg_indexes
+WHERE
+schemaname = :'schema'
+AND tablename = 'goal_target'
+AND indexname = 'goal_target_goal_id_plan_id_idx';
 
 ROLLBACK;

--- a/3-reveal/migrations/2-transaction_tables/verify/rework_plan_sub_tables.psql
+++ b/3-reveal/migrations/2-transaction_tables/verify/rework_plan_sub_tables.psql
@@ -1,0 +1,7 @@
+-- Verify reveal_transaction_tables:rework_plan_sub_tables on pg
+
+BEGIN;
+
+-- XXX Add verifications here.
+
+ROLLBACK;


### PR DESCRIPTION
- Remove unique constrains in plan sub tables
- Remove foreign key references to entities not related to plans
- (Not for Beam) Add useful indices