### PR TITLE
Add missing crucial fields to events table

### DIFF
--- a/3-reveal/migrations/2-transaction_tables/deploy/more_event_fields.psql
+++ b/3-reveal/migrations/2-transaction_tables/deploy/more_event_fields.psql
@@ -1,0 +1,18 @@
+-- Deploy reveal_transaction_tables:more_event_fields to pg
+-- requires: events
+
+BEGIN;
+
+SET search_path TO :"schema",public;
+
+-- adds missing event fields
+ALTER TABLE events
+ADD COLUMN structure_id VARCHAR(36) NULL,
+ADD COLUMN plan_id VARCHAR(36) NULL,
+ADD COLUMN details JSONB NOT NULL DEFAULT '{}'::jsonb;
+
+-- add indices for some of the above
+CREATE INDEX IF NOT EXISTS events_structure_id_idx ON events (structure_id);
+CREATE INDEX IF NOT EXISTS events_plan_id_idx ON events (plan_id);
+
+COMMIT;

--- a/3-reveal/migrations/2-transaction_tables/revert/more_event_fields.psql
+++ b/3-reveal/migrations/2-transaction_tables/revert/more_event_fields.psql
@@ -1,0 +1,15 @@
+-- Revert reveal_transaction_tables:more_event_fields from pg
+
+BEGIN;
+
+SET search_path TO :"schema",public;
+
+DROP INDEX events_structure_id_idx;
+DROP INDEX events_plan_id_idx;
+
+ALTER TABLE events
+DROP COLUMN structure_id,
+DROP COLUMN plan_id,
+DROP COLUMN details;
+
+COMMIT;

--- a/3-reveal/migrations/2-transaction_tables/sqitch.plan
+++ b/3-reveal/migrations/2-transaction_tables/sqitch.plan
@@ -19,3 +19,4 @@ location_status_indices [jurisdictions locations] 2020-08-27T17:52:14Z mosh <kja
 location_geo_ordering_indices [jurisdictions locations] 2020-09-01T12:08:22Z mosh <kjayanoris@ona.io> # Add location geo ordering indices.
 nullable_task_focus [tasks] 2020-09-01T12:13:14Z mosh <kjayanoris@ona.io> # Make task focus nullable.
 rework_plan_sub_tables [actions goal_target plan_jurisdiction] 2020-09-07T15:58:07Z mosh <kjayanoris@ona.io> # Rework plan sub tables.
+more_event_fields [events] 2020-09-08T12:40:38Z mosh <kjayanoris@ona.io> # Add more event fields.

--- a/3-reveal/migrations/2-transaction_tables/verify/more_event_fields.psql
+++ b/3-reveal/migrations/2-transaction_tables/verify/more_event_fields.psql
@@ -1,0 +1,41 @@
+-- Verify reveal_transaction_tables:more_event_fields on pg
+
+BEGIN;
+
+SET search_path TO :"schema",public;
+
+SELECT
+    id,
+    created_at,
+    base_entity_id,
+    location_id,
+    structure_id,
+    event_type,
+    provider_id,
+    date_created,
+    event_date,
+    entity_type,
+    form_data,
+    details,
+    task_id,
+    plan_id,
+    team_id,
+    server_version
+FROM events
+WHERE FALSE;
+
+SELECT 1/COUNT(*)
+FROM pg_catalog.pg_indexes
+WHERE
+schemaname = :'schema'
+AND tablename = 'events'
+AND indexname = 'events_structure_id_idx';
+
+SELECT 1/COUNT(*)
+FROM pg_catalog.pg_indexes
+WHERE
+schemaname = :'schema'
+AND tablename = 'events'
+AND indexname = 'events_plan_id_idx';
+
+ROLLBACK;


### PR DESCRIPTION
This PR adds the following missing fields

- structure_id - the id of the associated structure
- plan_id - the id of the associated plan
- details: a JSON field that contains the events details

@gstuder-ona @Wambere Let's note that while we add structure_id and plan_id as nullable, the ETL should consider that plan ids are required.  structure id is sometimes null