### PR TITLE
More performance improvements

### DIFF
--- a/3-reveal/migrations/2-transaction_tables/deploy/more_task_plan_settings_indices.psql
+++ b/3-reveal/migrations/2-transaction_tables/deploy/more_task_plan_settings_indices.psql
@@ -1,0 +1,21 @@
+-- Deploy reveal_transaction_tables:more_task_plan_settings_indices to pg
+-- requires: tasks
+-- requires: opensrp_settings
+-- requires: plans
+
+BEGIN;
+
+SET search_path TO :"schema",public;
+
+CREATE INDEX IF NOT EXISTS opensrp_settings_key_idx ON opensrp_settings (key);
+CREATE INDEX IF NOT EXISTS opensrp_settings_identifier_idx ON opensrp_settings (identifier);
+CREATE INDEX IF NOT EXISTS opensrp_settings_identifier_key_idx ON opensrp_settings (identifier, key);
+
+CREATE INDEX IF NOT EXISTS plans_status_idx ON plans (status);
+CREATE INDEX IF NOT EXISTS plans_intervention_type_idx ON plans (intervention_type);
+CREATE INDEX IF NOT EXISTS plans_status_intervention_type_idx ON plans (status, intervention_type);
+
+CREATE INDEX IF NOT EXISTS task_for_plan_code_status_idx ON tasks (task_for, plan_identifier, code, status);
+CREATE INDEX IF NOT EXISTS task_plan_code_bsuiness_status_status_idx ON tasks (plan_identifier, code, business_status, status);
+
+COMMIT;

--- a/3-reveal/migrations/2-transaction_tables/revert/more_task_plan_settings_indices.psql
+++ b/3-reveal/migrations/2-transaction_tables/revert/more_task_plan_settings_indices.psql
@@ -1,0 +1,16 @@
+-- Revert reveal_transaction_tables:more_task_plan_settings_indices from pg
+
+BEGIN;
+
+SET search_path TO :"schema",public;
+
+DROP INDEX IF EXISTS opensrp_settings_key_idx;
+DROP INDEX IF EXISTS opensrp_settings_identifier_idx;
+DROP INDEX IF EXISTS opensrp_settings_identifier_key_idx;
+DROP INDEX IF EXISTS plans_status_idx;
+DROP INDEX IF EXISTS plans_intervention_type_idx;
+DROP INDEX IF EXISTS plans_status_intervention_type_idx;
+DROP INDEX IF EXISTS task_for_plan_code_status_idx;
+DROP INDEX IF EXISTS task_plan_code_bsuiness_status_status_idx;
+
+COMMIT;

--- a/3-reveal/migrations/2-transaction_tables/sqitch.plan
+++ b/3-reveal/migrations/2-transaction_tables/sqitch.plan
@@ -20,3 +20,4 @@ location_geo_ordering_indices [jurisdictions locations] 2020-09-01T12:08:22Z mos
 nullable_task_focus [tasks] 2020-09-01T12:13:14Z mosh <kjayanoris@ona.io> # Make task focus nullable.
 rework_plan_sub_tables [actions goal_target plan_jurisdiction] 2020-09-07T15:58:07Z mosh <kjayanoris@ona.io> # Rework plan sub tables.
 more_event_fields [events] 2020-09-08T12:40:38Z mosh <kjayanoris@ona.io> # Add more event fields.
+more_task_plan_settings_indices [tasks opensrp_settings plans] 2020-09-10T16:43:09Z mosh <kjayanoris@ona.io> # Add more indices for tasks, plans, and settings.

--- a/3-reveal/migrations/2-transaction_tables/verify/more_task_plan_settings_indices.psql
+++ b/3-reveal/migrations/2-transaction_tables/verify/more_task_plan_settings_indices.psql
@@ -1,0 +1,63 @@
+-- Verify reveal_transaction_tables:more_task_plan_settings_indices on pg
+
+BEGIN;
+
+SET search_path TO :"schema",public;
+
+SELECT 1/COUNT(*)
+FROM pg_catalog.pg_indexes
+WHERE
+schemaname = :'schema'
+AND tablename = 'opensrp_settings'
+AND indexname = 'opensrp_settings_key_idx';
+
+SELECT 1/COUNT(*)
+FROM pg_catalog.pg_indexes
+WHERE
+schemaname = :'schema'
+AND tablename = 'opensrp_settings'
+AND indexname = 'opensrp_settings_identifier_idx';
+
+SELECT 1/COUNT(*)
+FROM pg_catalog.pg_indexes
+WHERE
+schemaname = :'schema'
+AND tablename = 'opensrp_settings'
+AND indexname = 'opensrp_settings_identifier_key_idx';
+
+SELECT 1/COUNT(*)
+FROM pg_catalog.pg_indexes
+WHERE
+schemaname = :'schema'
+AND tablename = 'plans'
+AND indexname = 'plans_status_idx';
+
+SELECT 1/COUNT(*)
+FROM pg_catalog.pg_indexes
+WHERE
+schemaname = :'schema'
+AND tablename = 'plans'
+AND indexname = 'plans_intervention_type_idx';
+
+SELECT 1/COUNT(*)
+FROM pg_catalog.pg_indexes
+WHERE
+schemaname = :'schema'
+AND tablename = 'plans'
+AND indexname = 'plans_status_intervention_type_idx';
+
+SELECT 1/COUNT(*)
+FROM pg_catalog.pg_indexes
+WHERE
+schemaname = :'schema'
+AND tablename = 'tasks'
+AND indexname = 'task_for_plan_code_status_idx';
+
+SELECT 1/COUNT(*)
+FROM pg_catalog.pg_indexes
+WHERE
+schemaname = :'schema'
+AND tablename = 'tasks'
+AND indexname = 'task_plan_code_bsuiness_status_status_idx';
+
+ROLLBACK;

--- a/3-reveal/migrations/6-MDA/Zambia-2020/deploy/mda_jurisdictions.psql
+++ b/3-reveal/migrations/6-MDA/Zambia-2020/deploy/mda_jurisdictions.psql
@@ -6,7 +6,7 @@ BEGIN;
 SET search_path TO :"schema",public;
 
 CREATE MATERIALIZED VIEW IF NOT EXISTS ntd_mda_jurisdictions AS
-SELECT DISTINCT ON (plans.identifier, jurisdictions_materialized_view.jurisdiction_id)
+SELECT
     public.uuid_generate_v5(
         '6ba7b810-9dad-11d1-80b4-00c04fd430c8',
         concat(plans.identifier, jurisdictions_materialized_view.jurisdiction_id)
@@ -22,14 +22,11 @@ SELECT DISTINCT ON (plans.identifier, jurisdictions_materialized_view.jurisdicti
     structures_query.structures_visited AS structures_visited,
     COALESCE(structures_query.structure_count, 0) AS structure_count,
     structures_query.sacregistered AS sacregistered,
-    -- structures_query.nPzqDistributedQuantity AS total_pzqdistributed,
-    tasks_query.nPzqDistributedQuantity AS total_pzqdistributed,
+    structures_query.nPzqDistributedQuantity AS total_pzqdistributed,
     CASE WHEN COALESCE(structures_query.structure_count, 0) <> 0 THEN structures_query.structures_visited::DECIMAL/structures_query.structure_count::DECIMAL ELSE 0 END AS structures_visited_per,
-    -- CASE WHEN structures_query.sacregistered <> 0 THEN structures_query.nPzqDistribute::DECIMAL/structures_query.sacregistered::DECIMAL ELSE 0 END AS registeredchildrentreated_per,
-    CASE WHEN structures_query.sacregistered <> 0 THEN tasks_query.nPzqDistribute::DECIMAL/structures_query.sacregistered::DECIMAL ELSE 0 END AS registeredchildrentreated_per,
+    CASE WHEN structures_query.sacregistered <> 0 THEN structures_query.nPzqDistribute::DECIMAL/structures_query.sacregistered::DECIMAL ELSE 0 END AS registeredchildrentreated_per,
     CASE WHEN COALESCE(jurisdiction_target_query.target, 0) <> 0 THEN structures_query.sacregistered::DECIMAL/jurisdiction_target_query.target::DECIMAL ELSE 0 END AS expectedchildren_found,
-    -- CASE WHEN COALESCE(jurisdiction_target_query.target, 0) <> 0 THEN structures_query.nPzqDistribute::DECIMAL/jurisdiction_target_query.target::DECIMAL ELSE 0 END AS expectedchildren_treated
-    CASE WHEN COALESCE(jurisdiction_target_query.target, 0) <> 0 THEN tasks_query.nPzqDistribute::DECIMAL/jurisdiction_target_query.target::DECIMAL ELSE 0 END AS expectedchildren_treated
+    CASE WHEN COALESCE(jurisdiction_target_query.target, 0) <> 0 THEN structures_query.nPzqDistribute::DECIMAL/jurisdiction_target_query.target::DECIMAL ELSE 0 END AS expectedchildren_treated
 FROM plans AS plans
 LEFT JOIN jurisdictions_materialized_view AS jurisdictions_materialized_view ON
     jurisdictions_materialized_view.jurisdiction_id IN (
@@ -42,11 +39,12 @@ LEFT JOIN plan_jurisdictions_materialized_view AS plan_jurisdictions
     AND plan_jurisdictions.jurisdiction_id = jurisdictions_materialized_view.jurisdiction_id
 LEFT JOIN LATERAL (
     SELECT
-    key as jurisdiction_id,
-    COALESCE(data->>'value', '0')::INTEGER AS target
+        key as jurisdiction_id,
+        COALESCE(data->>'value', '0')::INTEGER AS target
     FROM opensrp_settings
-    WHERE identifier = 'jurisdiction_metadata-population'
-    AND jurisdictions_materialized_view.jurisdiction_id = opensrp_settings.key
+    WHERE
+        identifier = 'jurisdiction_metadata-population'
+        AND jurisdictions_materialized_view.jurisdiction_id = opensrp_settings.key
     ORDER BY COALESCE(data->>'serverVersion', '0')::BIGINT DESC
     LIMIT 1
 ) AS jurisdiction_target_query ON true
@@ -54,24 +52,14 @@ LEFT JOIN LATERAL (
     SELECT
         COUNT(ntd_structures.location_id) AS structure_count,
         COALESCE(SUM(ntd_structures.structure_visited), 0) AS structures_visited,
-        COALESCE(SUM(ntd_structures.nsac), 0) AS sacregistered
-        -- COALESCE(SUM(ntd_structures.nPzqDistribute), 0) AS nPzqDistribute,
-        -- COALESCE(SUM(ntd_structures.nPzqDistributedQuantity), 0) AS nPzqDistributedQuantity
+        COALESCE(SUM(ntd_structures.nsac), 0) AS sacregistered,
+        COALESCE(SUM(ntd_structures.nPzqDistribute), 0) AS nPzqDistribute,
+        COALESCE(SUM(ntd_structures.nPzqDistributedQuantity), 0) AS nPzqDistributedQuantity
     FROM ntd_dispense_structures AS ntd_structures
     WHERE ntd_structures.plan_id = plans.identifier
     AND (jurisdictions_materialized_view.jurisdiction_id = ntd_structures.jurisdiction_id
     OR ntd_structures.jurisdiction_path @> ARRAY[jurisdictions_materialized_view.jurisdiction_id])
 ) AS structures_query ON true
-LEFT JOIN LATERAL (
-    SELECT
-        COALESCE(SUM(task_report.nPzqDistribute), 0) AS nPzqDistribute,
-        COALESCE(SUM(task_report.nPzqDistributedQuantity), 0) AS nPzqDistributedQuantity
-    FROM ntd_dispense_tasks AS task_report
-    WHERE
-        task_report.plan_id = plans.identifier
-        AND (jurisdictions_materialized_view.jurisdiction_id = task_report.jurisdiction_id
-        OR task_report.jurisdiction_path @> ARRAY[jurisdictions_materialized_view.jurisdiction_id])
-) AS tasks_query ON true
 WHERE
     plans.intervention_type = 'Dynamic-MDA'
     AND plans.status IN ('active', 'complete');

--- a/3-reveal/migrations/6-MDA/Zambia-2020/deploy/mda_structures.psql
+++ b/3-reveal/migrations/6-MDA/Zambia-2020/deploy/mda_structures.psql
@@ -12,29 +12,27 @@ BEGIN;
 SET search_path TO :"schema",public;
 
 CREATE OR REPLACE VIEW ntd_dispense_structures AS
-SELECT DISTINCT ON (locations.id, plans.identifier)
-    locations.id AS location_id,
+SELECT
     plans.identifier AS plan_id,
+    locations.id AS location_id,
     jurisdictions.jurisdiction_id AS jurisdiction_id,
     jurisdictions.jurisdiction_parent_id AS jurisdiction_parent_id,
     jurisdictions.jurisdiction_name AS jurisdiction_name,
     jurisdictions.jurisdiction_depth AS jurisdiction_depth,
     jurisdictions.jurisdiction_path AS jurisdiction_path,
     jurisdictions.jurisdiction_name_path AS jurisdiction_name_path,
-    -- COALESCE(mda_dispence_query.nPzqDistribute, 0) AS nPzqDistribute,
-    -- COALESCE(mda_dispence_query.availableForTreatment, 0) AS availableForTreatment,
-    -- COALESCE(mda_dispence_query.nPzqDistributedQuantity, 0) AS nPzqDistributedQuantity,
+    COALESCE(mda_dispence_query.nPzqDistribute, 0) AS nPzqDistribute,
+    COALESCE(mda_dispence_query.availableForTreatment, 0) AS availableForTreatment,
+    COALESCE(mda_dispence_query.nPzqDistributedQuantity, 0) AS nPzqDistributedQuantity,
     COALESCE(client_info_query.nsac, 0) AS nsac,
     COALESCE(client_info_query.visited, 0) AS structure_visited
-FROM locations AS locations
+FROM plans
 LEFT JOIN plan_jurisdiction AS plan_jurisdiction
+    ON plans.identifier = plan_jurisdiction.plan_id
+LEFT JOIN locations AS locations
     ON locations.jurisdiction_id = plan_jurisdiction.jurisdiction_id
-LEFT JOIN plans AS plans
-    ON plan_jurisdiction.plan_id = plans.identifier
-    AND plans.intervention_type = 'Dynamic-MDA'
-    AND plans.status IN ('active', 'complete')
 LEFT JOIN jurisdictions_materialized_view AS jurisdictions
-    ON locations.jurisdiction_id = jurisdictions.jurisdiction_id
+    ON plan_jurisdiction.jurisdiction_id = jurisdictions.jurisdiction_id
 LEFT JOIN LATERAL (
     SELECT
         COUNT(DISTINCT t1.identifier) AS visited,
@@ -44,58 +42,38 @@ LEFT JOIN LATERAL (
         ON t1.identifier = e2.task_id
     LEFT JOIN clients AS c1
         ON e2.base_entity_id = c1.baseentityid
-    WHERE t1.group_identifier = jurisdictions.jurisdiction_id
+    WHERE t1.group_identifier = plan_jurisdiction.jurisdiction_id
     AND t1.task_for = locations.id
     AND t1.plan_identifier = plans.identifier
     AND t1.code IN ('Structure_Visited', 'Structure Visited')
     AND t1.status IN ('Completed')
 ) AS client_info_query ON true
--- lets investigate if we can enable this section
--- LEFT JOIN LATERAL (
---     SELECT
---         CASE
---             WHEN e1.form_data->>'nPzqDistribute' = 'Yes' THEN 1
---             ELSE 0
---         END AS nPzqDistribute,
---         CASE
---             WHEN e1.form_data->>'availableForTreatment' = 'Yes' THEN 1
---             ELSE 0
---         END AS availableForTreatment,
---         CASE
---             WHEN e1.form_data->>'nPzqDistributedQuantity' IS NULL THEN 0
---             ELSE CAST(e1.form_data->>'nPzqDistributedQuantity' AS DECIMAL)
---         END AS nPzqDistributedQuantity
---     FROM tasks AS t2
---     LEFT JOIN events AS e1
---         ON t2.identifier = e1.task_id
---     -- LEFT JOIN clients AS c2
---     --     ON e1.base_entity_id = c2.baseentityid
---     WHERE t2.group_identifier = jurisdictions.jurisdiction_id
---     AND t2.plan_identifier = plans.identifier
---     AND t2.code IN ('MDA_Dispense')
---     AND t2.business_status NOT IN ('Not Visited')
---     AND t2.status NOT IN ('Cancelled')
---     -- AND c2.residence = locations.id
--- ) AS mda_dispence_query ON true
-WHERE plans.identifier IS NOT NULL;
-
--- it may be possible to not need this view if the info can be gotten
--- through ntd_dispense_structures
-CREATE OR REPLACE VIEW ntd_dispense_tasks AS
-SELECT
-    tasks.plan_identifier AS plan_id,
-    jurisdictions.jurisdiction_id AS jurisdiction_id,
-    jurisdictions.jurisdiction_path AS jurisdiction_path,
-    COALESCE(COUNT(id) FILTER (WHERE events.form_data->>'nPzqDistribute' = 'Yes'), 0) AS nPzqDistribute,
-    COALESCE(SUM(coalesce(form_data->>'nPzqDistributedQuantity', '0')::DECIMAL), 0) AS nPzqDistributedQuantity
-FROM events
-LEFT JOIN tasks AS tasks ON
-    events.task_id = tasks.identifier
-LEFT JOIN jurisdictions_materialized_view AS jurisdictions
-    ON tasks.group_identifier = jurisdictions.jurisdiction_id
-WHERE tasks.code IN ('MDA_Dispense')
-AND tasks.status NOT IN ('Cancelled')
-AND tasks.business_status NOT IN ('Not Visited')
-GROUP BY tasks.plan_identifier, jurisdictions.jurisdiction_id, jurisdictions.jurisdiction_path;
+LEFT JOIN LATERAL (
+    SELECT
+        CASE
+            WHEN e1.form_data->>'nPzqDistribute' = 'Yes' THEN 1
+            ELSE 0
+        END AS nPzqDistribute,
+        CASE
+            WHEN e1.form_data->>'availableForTreatment' = 'Yes' THEN 1
+            ELSE 0
+        END AS availableForTreatment,
+        COALESCE(COALESCE(e1.form_data->>'nPzqDistributedQuantity', '0')::DECIMAL, 0) AS nPzqDistributedQuantity
+    FROM tasks AS t2
+    LEFT JOIN events AS e1
+        ON t2.identifier = e1.task_id
+    LEFT JOIN clients AS c1
+        ON t2.task_for = c1.baseentityid
+    WHERE c1.residence = locations.id
+    AND t2.group_identifier = plan_jurisdiction.jurisdiction_id
+    AND t2.plan_identifier = plans.identifier
+    AND t2.code IN ('MDA_Dispense')
+    AND t2.business_status NOT IN ('Not Visited')
+    AND t2.status NOT IN ('Cancelled')
+) AS mda_dispence_query ON true
+WHERE
+    plans.intervention_type = 'Dynamic-MDA'
+    AND plans.status IN ('active', 'complete')
+    AND locations.id IS NOT NULL;
 
 COMMIT;

--- a/3-reveal/migrations/6-MDA/Zambia-2020/revert/mda_structures.psql
+++ b/3-reveal/migrations/6-MDA/Zambia-2020/revert/mda_structures.psql
@@ -5,6 +5,5 @@ BEGIN;
 SET search_path TO :"schema",public;
 
 DROP VIEW ntd_dispense_structures CASCADE;
-DROP VIEW ntd_dispense_tasks CASCADE;
 
 COMMIT;

--- a/3-reveal/migrations/6-MDA/Zambia-2020/verify/mda_structures.psql
+++ b/3-reveal/migrations/6-MDA/Zambia-2020/verify/mda_structures.psql
@@ -5,7 +5,6 @@ BEGIN;
 SET search_path TO :"schema",public;
 
 SELECT 1/COUNT(*) FROM pg_views WHERE schemaname = :'schema' AND viewname = 'ntd_dispense_structures';
-SELECT 1/COUNT(*) FROM pg_views WHERE schemaname = :'schema' AND viewname = 'ntd_dispense_tasks';
 
 SELECT
     location_id,
@@ -19,15 +18,6 @@ SELECT
     nsac,
     structure_visited
 FROM ntd_dispense_structures
-WHERE FALSE;
-
-SELECT
-    plan_id,
-    jurisdiction_id,
-    jurisdiction_path,
-    npzqdistribute,
-    npzqdistributedquantity
-FROM ntd_dispense_tasks
 WHERE FALSE;
 
 ROLLBACK;


### PR DESCRIPTION
This PR:

- Improves Zambia MDA (NTD) reports .  Specifically:
    - the view named `ntd_dispense_tasks` is merged into `ntd_dispense_structures`
    - `ntd_dispense_structures` is re-written to be based off of plans instead of locations (mainly utilizes the ideas here: #24)
- Adds more indices to tasks table to aid in the NTD performance improvements
- Adds indices to plans and opensrp_settings table that should benefit all reports' performance