### PR TITLE
Beam pilot fixes volume3

### DIFF
--- a/1-utils/deploy/refresh_mat_views.psql
+++ b/1-utils/deploy/refresh_mat_views.psql
@@ -7,31 +7,55 @@ BEGIN;
 -- :"schema" variable - and default to public.
 SET search_path TO :"schema",public;
 
-CREATE OR REPLACE FUNCTION refresh_mat_view(view_name VARCHAR, concurrent BOOLEAN DEFAULT TRUE) RETURNS VOID AS $$
+CREATE OR REPLACE FUNCTION refresh_mat_view(view_name VARCHAR, concurrent BOOLEAN DEFAULT TRUE, check_schema BOOLEAN DEFAULT FALSE) RETURNS VARCHAR AS $$
 -- this function is used to refresh a materialized view and simultaneously record
 -- the time that the refresh started and finished
 -- params:
 --      view_name - the name of the materialized view
 --      concurrent - whether to refresh concurrently or not
+--      check_schema - whether to check for ongoing refreshes in the current schema or not
+DECLARE
+    refresh_statement VARCHAR;
+    check_existing_stmnt VARCHAR;
+    existing_queries INTEGER;
 BEGIN
-
-    -- record the start time
-    INSERT INTO materialized_view_tracking (name, start, finish)
-    VALUES (view_name, CLOCK_TIMESTAMP(), NULL)
-    ON CONFLICT (name) DO UPDATE
-    SET start = CLOCK_TIMESTAMP(), finish = NULL;
-
-    -- refresh the view
-    IF concurrent = TRUE THEN
-        EXECUTE 'REFRESH MATERIALIZED VIEW CONCURRENTLY ' || view_name;
+    -- check if we should refresh
+    IF check_schema = TRUE THEN
+        check_existing_stmnt = CONCAT('%', current_schema(), '.refresh_mat_view(''', 'zambia_irs_export', '%');
     ELSE
-        EXECUTE 'REFRESH MATERIALIZED VIEW ' || view_name;
+        check_existing_stmnt = CONCAT('%refresh_mat_view(''', view_name, '%');
     END IF;
 
-    -- record the end time
-    UPDATE materialized_view_tracking
-    SET finish = CLOCK_TIMESTAMP()
-    WHERE name = view_name;
+    SELECT COUNT(*) FROM pg_stat_activity
+    INTO existing_queries
+    WHERE query ILIKE check_existing_stmnt;
+
+    IF existing_queries > 1 THEN
+        RETURN view_name || ' refresh already in progress.';
+    ELSE
+        -- get the refresh statement
+        IF concurrent = TRUE THEN
+            refresh_statement = 'REFRESH MATERIALIZED VIEW CONCURRENTLY ' || view_name;
+        ELSE
+            refresh_statement = 'REFRESH MATERIALIZED VIEW ' || view_name;
+        END IF;
+
+        -- record the start time
+        INSERT INTO materialized_view_tracking (name, start, finish)
+        VALUES (view_name, CLOCK_TIMESTAMP(), NULL)
+        ON CONFLICT (name) DO UPDATE
+        SET start = CLOCK_TIMESTAMP(), finish = NULL;
+
+        -- refresh the view
+        EXECUTE refresh_statement;
+
+        -- record the end time
+        UPDATE materialized_view_tracking
+        SET finish = CLOCK_TIMESTAMP()
+        WHERE name = view_name;
+
+        RETURN refresh_statement;
+    END IF;
 
 END;
 $$ LANGUAGE plpgsql;

--- a/1-utils/revert/refresh_mat_views.psql
+++ b/1-utils/revert/refresh_mat_views.psql
@@ -4,6 +4,6 @@ BEGIN;
 
 SET search_path TO :"schema",public;
 
-DROP FUNCTION IF EXISTS refresh_mat_view(varchar, boolean);
+DROP FUNCTION IF EXISTS refresh_mat_view(varchar, boolean, boolean);
 
 COMMIT;

--- a/1-utils/verify/refresh_mat_views.psql
+++ b/1-utils/verify/refresh_mat_views.psql
@@ -4,7 +4,7 @@ BEGIN;
 
 SET search_path TO :"schema",public;
 
-SELECT has_function_privilege(:'schema' || '.refresh_mat_view(varchar, boolean)', 'execute');
+SELECT has_function_privilege(:'schema' || '.refresh_mat_view(varchar, boolean, boolean)', 'execute');
 
 CREATE TABLE refresh_mat_view_users (
     nickname  TEXT PRIMARY KEY,

--- a/3-reveal/jobs/performance/vacuum.psql
+++ b/3-reveal/jobs/performance/vacuum.psql
@@ -6,7 +6,7 @@ SELECT
   pg_cancel_backend(pid) as canceled
 FROM pg_stat_activity
 WHERE (now() - pg_stat_activity.query_start) > interval '1 minutes'
-AND usename in ('canopy', 'reveal');
+AND (query ILIKE '%refresh_mat_view%' OR query ILIKE '%structure_geo_hierarchy%');
 
 -- vacuum stuff
 SELECT NOW();

--- a/3-reveal/migrations/2-transaction_tables/deploy/plan_server_version_drop_location_uuid_constraint.psql
+++ b/3-reveal/migrations/2-transaction_tables/deploy/plan_server_version_drop_location_uuid_constraint.psql
@@ -12,4 +12,7 @@ ADD COLUMN server_version BIGINT NOT NULL DEFAULT 0;
 ALTER TABLE locations
 DROP CONSTRAINT locations_uid_key;
 
+ALTER TABLE events
+ALTER COLUMN task_id DROP NOT NULL;
+
 COMMIT;

--- a/3-reveal/migrations/2-transaction_tables/deploy/plan_server_version_drop_location_uuid_constraint.psql
+++ b/3-reveal/migrations/2-transaction_tables/deploy/plan_server_version_drop_location_uuid_constraint.psql
@@ -1,0 +1,15 @@
+-- Deploy reveal_transaction_tables:plan_server_version_drop_location_uuid_constraint to pg
+-- requires: locations
+-- requires: plans
+
+BEGIN;
+
+SET search_path TO :"schema",public;
+
+ALTER TABLE plans
+ADD COLUMN server_version BIGINT NOT NULL DEFAULT 0;
+
+ALTER TABLE locations
+DROP CONSTRAINT locations_uid_key;
+
+COMMIT;

--- a/3-reveal/migrations/2-transaction_tables/revert/plan_server_version_drop_location_uuid_constraint.psql
+++ b/3-reveal/migrations/2-transaction_tables/revert/plan_server_version_drop_location_uuid_constraint.psql
@@ -10,4 +10,6 @@ DROP COLUMN server_version;
 ALTER TABLE locations
 ADD CONSTRAINT locations_uid_key UNIQUE (uid);
 
+ALTER TABLE events ALTER COLUMN task_id SET NOT NULL;
+
 COMMIT;

--- a/3-reveal/migrations/2-transaction_tables/revert/plan_server_version_drop_location_uuid_constraint.psql
+++ b/3-reveal/migrations/2-transaction_tables/revert/plan_server_version_drop_location_uuid_constraint.psql
@@ -1,0 +1,13 @@
+-- Revert reveal_transaction_tables:plan_server_version_drop_location_uuid_constraint from pg
+
+BEGIN;
+
+SET search_path TO :"schema",public;
+
+ALTER TABLE plans
+DROP COLUMN server_version;
+
+ALTER TABLE locations
+ADD CONSTRAINT locations_uid_key UNIQUE (uid);
+
+COMMIT;

--- a/3-reveal/migrations/2-transaction_tables/sqitch.plan
+++ b/3-reveal/migrations/2-transaction_tables/sqitch.plan
@@ -21,3 +21,4 @@ nullable_task_focus [tasks] 2020-09-01T12:13:14Z mosh <kjayanoris@ona.io> # Make
 rework_plan_sub_tables [actions goal_target plan_jurisdiction] 2020-09-07T15:58:07Z mosh <kjayanoris@ona.io> # Rework plan sub tables.
 more_event_fields [events] 2020-09-08T12:40:38Z mosh <kjayanoris@ona.io> # Add more event fields.
 more_task_plan_settings_indices [tasks opensrp_settings plans] 2020-09-10T16:43:09Z mosh <kjayanoris@ona.io> # Add more indices for tasks, plans, and settings.
+plan_server_version_drop_location_uuid_constraint [locations plans] 2020-09-15T08:26:38Z mosh <kjayanoris@ona.io> # Add plan server version and drop location uuid unique.

--- a/3-reveal/migrations/2-transaction_tables/verify/plan_server_version_drop_location_uuid_constraint.psql
+++ b/3-reveal/migrations/2-transaction_tables/verify/plan_server_version_drop_location_uuid_constraint.psql
@@ -1,0 +1,35 @@
+-- Verify reveal_transaction_tables:plan_server_version_drop_location_uuid_constraint on pg
+
+BEGIN;
+
+SET search_path TO :"schema",public;
+
+SELECT 1/COUNT(*)
+FROM (
+    SELECT COUNT(*)
+    FROM pg_catalog.pg_indexes
+    WHERE
+    schemaname = :'schema'
+    AND tablename = 'locations'
+    AND indexname = 'locations_uid_key'
+) AS foo
+WHERE count = 0;
+
+SELECT
+    identifier,
+    created_at,
+    version,
+    name,
+    title,
+    status,
+    fi_status,
+    fi_reason,
+    intervention_type,
+    date,
+    server_version,
+    effective_period_start,
+    effective_period_end
+FROM plans
+WHERE FALSE;
+
+ROLLBACK;

--- a/3-reveal/migrations/2-transaction_tables/verify/plan_server_version_drop_location_uuid_constraint.psql
+++ b/3-reveal/migrations/2-transaction_tables/verify/plan_server_version_drop_location_uuid_constraint.psql
@@ -32,4 +32,12 @@ SELECT
 FROM plans
 WHERE FALSE;
 
+SELECT 1/COUNT(*) FROM
+INFORMATION_SCHEMA.COLUMNS
+WHERE
+    table_schema = :'schema'
+    AND table_name = 'events'
+    AND column_name = 'task_id'
+    AND is_nullable = 'YES';
+
 ROLLBACK;

--- a/3-reveal/migrations/5-IRS/2-Zambia-2019/deploy/process_structure_geo_hierarchy_queue.psql
+++ b/3-reveal/migrations/5-IRS/2-Zambia-2019/deploy/process_structure_geo_hierarchy_queue.psql
@@ -58,7 +58,7 @@ DECLARE
 BEGIN
     -- check if we are already running this query
     SELECT COUNT(*) FROM pg_stat_activity
-    -- INTO existing_queries
+    INTO existing_queries
     WHERE (now() - pg_stat_activity.query_start) > interval '1 minutes'
     AND query ILIKE '%process_structure_geo_hierarchy_structure_queue%';
     -- only process the queue if not already doing it

--- a/3-reveal/migrations/5-IRS/2-Zambia-2019/deploy/process_structure_geo_hierarchy_queue.psql
+++ b/3-reveal/migrations/5-IRS/2-Zambia-2019/deploy/process_structure_geo_hierarchy_queue.psql
@@ -54,25 +54,32 @@ CREATE FUNCTION process_structure_geo_hierarchy_structure_queue(num_rows INTEGER
 DECLARE
     structure_row locations%ROWTYPE;
     structure_row_result BOOLEAN;
+    existing_queries INTEGER;
 BEGIN
-
-    FOR structure_row IN
-        -- first get the relevant locations
-        SELECT locations.*
-        FROM structure_geo_hierarchy_structure_queue
-        LEFT JOIN locations
-        ON locations.id = structure_geo_hierarchy_structure_queue.structure_id
-        LIMIT (num_rows)
-    LOOP
-        -- next lets process them
-        SELECT create_structure_geo_hierarchy(structure_row) INTO structure_row_result;
-        IF FOUND AND structure_row_result THEN
-            -- finally delete the locations from the queue
-            DELETE FROM structure_geo_hierarchy_structure_queue
-            WHERE structure_id = structure_row.id;
-        END IF;
-    END LOOP;
-
+    -- check if we are already running this query
+    SELECT COUNT(*) FROM pg_stat_activity
+    -- INTO existing_queries
+    WHERE (now() - pg_stat_activity.query_start) > interval '1 minutes'
+    AND query ILIKE '%process_structure_geo_hierarchy_structure_queue%';
+    -- only process the queue if not already doing it
+    IF existing_queries < 1 THEN
+        FOR structure_row IN
+            -- first get the relevant locations
+            SELECT locations.*
+            FROM structure_geo_hierarchy_structure_queue
+            LEFT JOIN locations
+            ON locations.id = structure_geo_hierarchy_structure_queue.structure_id
+            LIMIT (num_rows)
+        LOOP
+            -- next lets process them
+            SELECT create_structure_geo_hierarchy(structure_row) INTO structure_row_result;
+            IF FOUND AND structure_row_result THEN
+                -- finally delete the locations from the queue
+                DELETE FROM structure_geo_hierarchy_structure_queue
+                WHERE structure_id = structure_row.id;
+            END IF;
+        END LOOP;
+    END IF;
 END;
 $$ LANGUAGE plpgsql;
 
@@ -85,10 +92,20 @@ CREATE FUNCTION process_structure_geo_hierarchy_jurisdiction_queue() RETURNS VOI
 -- WARNING: this is an expensive query!!
 DECLARE
     queue_count INTEGER;
+    existing_queries INTEGER;
 BEGIN
-    SELECT count(id) FROM structure_geo_hierarchy_jurisdiction_queue INTO queue_count;
-    IF queue_count > 0 THEN
-        PERFORM process_structure_geo_hierarchy_full();
+    -- check if we are already running this query
+    SELECT COUNT(*) FROM pg_stat_activity
+    INTO existing_queries
+    WHERE (now() - pg_stat_activity.query_start) > interval '1 minutes'
+    AND query ILIKE '%process_structure_geo_hierarchy_jurisdiction_queue%';
+    -- only process the queue if not already doing it
+    IF existing_queries < 1 THEN
+        -- only process the queue if it is populated
+        SELECT count(id) FROM structure_geo_hierarchy_jurisdiction_queue INTO queue_count;
+        IF queue_count > 0 THEN
+            PERFORM process_structure_geo_hierarchy_full();
+        END IF;
     END IF;
 END;
 $$ LANGUAGE plpgsql;


### PR DESCRIPTION
Changes included:

- Ensure queries to refresh materialized views do not pile up by checking that we are not refreshing the same view more than once at a time
- Ensure structure geo processing queries do not pile up by checking that we are not the same query more than once at a time
- Fix the plans, events and locations tables to work well with Beam
- Improve vacuuming query