### PR TITLE
Update the targets_materialized_views

### DIFF
--- a/3-reveal/migrations/4-FI/1-Thailand-2019/deploy/targets_materialized_view.psql
+++ b/3-reveal/migrations/4-FI/1-Thailand-2019/deploy/targets_materialized_view.psql
@@ -76,6 +76,7 @@ LEFT JOIN LATERAL (
         AND code = actions.code
         AND group_identifier = plan_jurisdiction.jurisdiction_id
         AND business_status IN ('Complete', 'Sprayed')
+        AND status IN ('Ready', 'Completed')
 ) AS subq1 ON true
 LEFT JOIN LATERAL (
     SELECT

--- a/3-reveal/migrations/4-FI/1-Thailand-2019/deploy/targets_materialized_view.psql
+++ b/3-reveal/migrations/4-FI/1-Thailand-2019/deploy/targets_materialized_view.psql
@@ -76,7 +76,7 @@ LEFT JOIN LATERAL (
         AND code = actions.code
         AND group_identifier = plan_jurisdiction.jurisdiction_id
         AND business_status IN ('Complete', 'Sprayed')
-        AND status IN ('Ready', 'Completed')
+        AND status NOT IN ('Archived', 'Cancelled')
 ) AS subq1 ON true
 LEFT JOIN LATERAL (
     SELECT

--- a/3-reveal/migrations/4-FI/1-Thailand-2019/deploy/task_structures_materialized_view.psql
+++ b/3-reveal/migrations/4-FI/1-Thailand-2019/deploy/task_structures_materialized_view.psql
@@ -61,7 +61,7 @@ LEFT JOIN LATERAL (
     ON locations.id = clients.residence
     WHERE clients.baseEntityId = tasks.task_for
 ) AS structures_query2 ON true
-WHERE tasks.status IN ('Ready', 'Completed')
+WHERE tasks.status NOT IN ('Archived', 'Cancelled')
 ORDER BY tasks.identifier;
 
 CREATE INDEX IF NOT EXISTS task_structures_materialized_view_plan_idx ON task_structures_materialized_view (plan_id);

--- a/3-reveal/migrations/4-FI/1-Thailand-2019/deploy/task_structures_materialized_view.psql
+++ b/3-reveal/migrations/4-FI/1-Thailand-2019/deploy/task_structures_materialized_view.psql
@@ -61,6 +61,7 @@ LEFT JOIN LATERAL (
     ON locations.id = clients.residence
     WHERE clients.baseEntityId = tasks.task_for
 ) AS structures_query2 ON true
+WHERE tasks.status IN ('Ready', 'Completed')
 ORDER BY tasks.identifier;
 
 CREATE INDEX IF NOT EXISTS task_structures_materialized_view_plan_idx ON task_structures_materialized_view (plan_id);


### PR DESCRIPTION
Update the targets_materialized_views to include 'Ready' OR 'Completed' task status.

fixes #https://github.com/onaio/reveal-frontend/issues/1304