### PR TITLE
Fix parent ids to be NULL not empty string

### DIFF
--- a/3-reveal/migrations/3-views/deploy/jurisdictions_materialized_view.psql
+++ b/3-reveal/migrations/3-views/deploy/jurisdictions_materialized_view.psql
@@ -23,7 +23,7 @@ WITH RECURSIVE tree AS
     -- setting this to id includes current object
     -- setting to parent_id includes only children
     -- setting to '' gets the whole tree
-    WHERE jurisdictions.parent_id = ''
+    WHERE jurisdictions.parent_id IS NULL OR jurisdictions.parent_id = ''
     UNION ALL
 --recursive part
 SELECT


### PR DESCRIPTION
It's a pretty small fix, but will impact virtually every matview we already have for reveal.  There's no way to point the derived matviews at a different target - we'll have to drop and recreate them.

Not at all sure what to do here but this is the fix.

Fixes onaio/canopy#1527

