### PR TITLE
Enhance zambia_irs_structures

### DIFF
--- a/3-reveal/jobs/materialized-views/IRS/Zambia-2019/refresh_irs_reports.sql
+++ b/3-reveal/jobs/materialized-views/IRS/Zambia-2019/refresh_irs_reports.sql
@@ -1,4 +1,5 @@
 -- Suggestion is to refresh this every 15min
-SELECT refresh_mat_view('zambia_irs_structures', TRUE);
+SELECT refresh_mat_view('zambia_irs_structures', FALSE);
+SELECT refresh_mat_view('zambia_irs_structures_data', TRUE);
 SELECT refresh_mat_view('zambia_focus_area_irs', TRUE);
 SELECT refresh_mat_view('zambia_irs_jurisdictions', TRUE);

--- a/3-reveal/jobs/materialized-views/IRS/Zambia-2019/refresh_zambia_irs_export.sql
+++ b/3-reveal/jobs/materialized-views/IRS/Zambia-2019/refresh_zambia_irs_export.sql
@@ -1,2 +1,2 @@
 -- Suggestion is to refresh this every 6hr and adjust as needed
-SELECT refresh_mat_view('zambia_irs_export', TRUE);
+SELECT refresh_mat_view('zambia_irs_export', FALSE);

--- a/3-reveal/migrations/5-IRS/4-Zambia-2020/deploy/zambia_irs_structures_geojson.psql
+++ b/3-reveal/migrations/5-IRS/4-Zambia-2020/deploy/zambia_irs_structures_geojson.psql
@@ -1,0 +1,72 @@
+-- Deploy reveal_irs_zambia_2020:zambia_irs_structures_geojson to pg
+-- requires: reveal_irs_zambia_2019:zambia_irs_structures
+
+BEGIN;
+
+SET search_path TO :"schema",public;
+
+-- We are creating a materialized view that exposes data from zambia_irs_structures
+-- as a materialized view withput the geometry column.  This is being done because
+-- in production zambia_irs_structures is not being refreshed concurrently and so we
+-- needs its data available for reporting even during its refreshing.
+CREATE MATERIALIZED VIEW IF NOT EXISTS zambia_irs_structures_data
+AS
+SELECT
+    id,
+    structure_id,
+    structure_jurisdiction_id,
+    structure_code,
+    structure_name,
+    structure_type,
+    task_id,
+    plan_id,
+    event_date,
+    business_status,
+    rooms_eligible,
+    rooms_sprayed,
+    eligibility,
+    structure_sprayed
+FROM zambia_irs_structures;
+CREATE UNIQUE INDEX IF NOT EXISTS zambia_irs_structures_data_idx ON zambia_irs_structures_data(id);
+CREATE INDEX IF NOT EXISTS zambia_irs_structures_data_jurisdiction_idx ON zambia_irs_structures_data(structure_jurisdiction_id);
+CREATE INDEX IF NOT EXISTS zambia_irs_structures_data_plan_idx ON zambia_irs_structures_data(plan_id);
+CREATE INDEX IF NOT EXISTS zambia_irs_structures_data_jurisdiction_plan_idx ON zambia_irs_structures_data(structure_jurisdiction_id, plan_id);
+
+-- This view takes zambia_irs_structures_data and adds structure geometry
+-- This view is the one that is actually exposed directly to reporting applications
+CREATE OR REPLACE VIEW zambia_irs_structures_geojson AS
+SELECT
+    id::VARCHAR,
+    structure_id,
+    structure_jurisdiction_id as jurisdiction_id,
+    task_id,
+    plan_id,
+    jsonb_build_object(
+        'type',         'Feature',
+        'id',           structure_id,
+        'geometry',     public.ST_AsGeoJSON(structure_geometry)::jsonb,
+        'properties',   to_jsonb(row) - 'structure_id' - 'structure_geometry'
+    ) AS geojson
+FROM (
+    SELECT
+        zambia_irs_structures_data.id AS id,
+        zambia_irs_structures_data.structure_id AS structure_id,
+        zambia_irs_structures_data.structure_jurisdiction_id AS structure_jurisdiction_id,
+        zambia_irs_structures_data.structure_code AS structure_code,
+        zambia_irs_structures_data.structure_name AS structure_name,
+        zambia_irs_structures_data.structure_type AS structure_type,
+        locations.geometry AS structure_geometry,
+        zambia_irs_structures_data.task_id AS task_id,
+        zambia_irs_structures_data.plan_id AS plan_id,
+        zambia_irs_structures_data.event_date AS event_date,
+        zambia_irs_structures_data.business_status AS business_status,
+        zambia_irs_structures_data.rooms_eligible AS rooms_eligible,
+        zambia_irs_structures_data.rooms_sprayed AS rooms_sprayed,
+        zambia_irs_structures_data.eligibility AS eligibility,
+        zambia_irs_structures_data.structure_sprayed AS structure_sprayed,
+        zambia_irs_structures_data.business_status AS business_status
+    FROM zambia_irs_structures_data
+    LEFT JOIN locations ON zambia_irs_structures_data.structure_id = locations.id
+) row;
+
+COMMIT;

--- a/3-reveal/migrations/5-IRS/4-Zambia-2020/revert/zambia_irs_structures_geojson.psql
+++ b/3-reveal/migrations/5-IRS/4-Zambia-2020/revert/zambia_irs_structures_geojson.psql
@@ -1,0 +1,9 @@
+-- Revert reveal_irs_zambia_2020:zambia_irs_structures_geojson from pg
+
+BEGIN;
+
+SET search_path TO :"schema",public;
+
+DROP MATERIALIZED VIEW zambia_irs_structures_data CASCADE;
+
+COMMIT;

--- a/3-reveal/migrations/5-IRS/4-Zambia-2020/sqitch.plan
+++ b/3-reveal/migrations/5-IRS/4-Zambia-2020/sqitch.plan
@@ -12,3 +12,4 @@ zambia_irs_data_collector_performance [zambia_irs_spray_event zambia_daily_summa
 zambia_irs_sop_performance [zambia_irs_spray_event zambia_daily_summary_event zambia_irs_sop_avg_time] 2020-09-02T14:53:31Z Ona,,, <ona@ona-ThinkPad-T470> # Creates irs sop report materialized view.
 zambia_irs_sop_date_performance [zambia_irs_spray_event zambia_daily_summary_event] 2020-09-02T15:03:33Z Ona,,, <ona@ona-ThinkPad-T470> # Creates irs sop by date report materialized view.
 zambia_irs_mop_up 2020-10-02T10:00:50Z gstuder,,, <gstuder@gstuder-ThinkPad-T490> # Changes for Zambia IRS mop-up reports
+zambia_irs_structures_geojson [reveal_irs_zambia_2019:zambia_irs_structures] 2020-10-15T16:08:43Z mosh <kjayanoris@ona.io> # Add zambia_irs_structures_geojson.

--- a/3-reveal/migrations/5-IRS/4-Zambia-2020/verify/zambia_irs_structures_geojson.psql
+++ b/3-reveal/migrations/5-IRS/4-Zambia-2020/verify/zambia_irs_structures_geojson.psql
@@ -1,0 +1,70 @@
+-- Verify reveal_irs_zambia_2020:zambia_irs_structures_geojson on pg
+
+BEGIN;
+
+SET search_path TO :"schema",public;
+
+SELECT 1/count(*)
+FROM pg_matviews
+WHERE matviewname = 'zambia_irs_structures_data';
+
+SELECT
+    id,
+    structure_id,
+    structure_jurisdiction_id,
+    structure_code,
+    structure_name,
+    structure_type,
+    task_id,
+    plan_id,
+    event_date,
+    business_status,
+    rooms_eligible,
+    rooms_sprayed,
+    eligibility,
+    structure_sprayed
+FROM zambia_irs_structures_data
+WHERE FALSE;
+
+SELECT 1/COUNT(*)
+FROM pg_catalog.pg_indexes
+WHERE
+schemaname = :'schema'
+AND tablename = 'zambia_irs_structures_data'
+AND indexdef LIKE '%CREATE UNIQUE INDEX%'
+AND indexname = 'zambia_irs_structures_data_idx';
+
+SELECT 1/COUNT(*)
+FROM pg_catalog.pg_indexes
+WHERE
+schemaname = :'schema'
+AND tablename = 'zambia_irs_structures_data'
+AND indexname = 'zambia_irs_structures_data_jurisdiction_idx';
+
+SELECT 1/COUNT(*)
+FROM pg_catalog.pg_indexes
+WHERE
+schemaname = :'schema'
+AND tablename = 'zambia_irs_structures_data'
+AND indexname = 'zambia_irs_structures_data_plan_idx';
+
+SELECT 1/COUNT(*)
+FROM pg_catalog.pg_indexes
+WHERE
+schemaname = :'schema'
+AND tablename = 'zambia_irs_structures_data'
+AND indexname = 'zambia_irs_structures_data_jurisdiction_plan_idx';
+
+SELECT 1/COUNT(*) FROM pg_views WHERE schemaname = :'schema' AND viewname = 'zambia_irs_structures_geojson';
+
+SELECT
+    id,
+    structure_id,
+    jurisdiction_id,
+    task_id,
+    plan_id,
+    geojson
+FROM zambia_irs_structures_geojson
+WHERE FALSE;
+
+ROLLBACK;


### PR DESCRIPTION
Following the discussions here https://github.com/onaio/canopy/issues/1502#issuecomment-708360396, we decided to NOT refresh zambia_irs_structures concurrently.  This means that during its refresh it will not be able to SELECT from it.

Therefore, to ensure that reporting apps are not affected we are implementing:

- zambia_irs_structures_data: a materialized view that exposes data from zambia_irs_structures which will be refreshed concurrently right after zambia_irs_structures is refreshed.
- zambia_irs_structures_geojson: a view (not materialized) that is consumed by reporting apps to expose all the data from zambia_irs_structures

This is part of https://github.com/OpenSRP/opensrp-reveal-datawarehouse/issues/33