### PR TITLE
Drop tasks constraint in events table

### DIFF
--- a/3-reveal/migrations/7-thai-only/deploy/drop_task_constraint.psql
+++ b/3-reveal/migrations/7-thai-only/deploy/drop_task_constraint.psql
@@ -1,0 +1,11 @@
+-- Deploy thailand_only:drop_task_constraint to pg
+-- requires: events
+
+BEGIN;
+
+SET search_path TO :"schema",public;
+
+ALTER TABLE events
+DROP CONSTRAINT IF EXISTS fk_events_task;
+
+COMMIT;

--- a/3-reveal/migrations/7-thai-only/revert/drop_task_constraint.psql
+++ b/3-reveal/migrations/7-thai-only/revert/drop_task_constraint.psql
@@ -1,0 +1,14 @@
+-- Revert thailand_only:drop_task_constraint from pg
+
+BEGIN;
+
+SET search_path TO :"schema",public;
+
+ALTER TABLE events
+ADD CONSTRAINT fk_events_task
+    FOREIGN KEY (task_id)
+    REFERENCES tasks(identifier)
+    ON DELETE CASCADE
+    ON UPDATE CASCADE;
+
+COMMIT;

--- a/3-reveal/migrations/7-thai-only/sqitch.plan
+++ b/3-reveal/migrations/7-thai-only/sqitch.plan
@@ -7,3 +7,4 @@ raw_organizations 2020-10-09T06:47:12Z Wambere <jwambere@ona.io> # Create table 
 raw_providers 2020-10-09T06:47:29Z Wambere <jwambere@ona.io> # Create table for raw_providers.
 biophics_columns [opensrp_common_raw_tables:raw_events reveal_raw_tables:raw_clients] 2020-10-09T07:12:14Z Wambere <jwambere@ona.io> # Add extra Biophics columns.
 raw_tables_modifications [reveal_raw_tables:raw_clients opensrp_common_raw_tables:raw_events] 2020-10-10T07:45:25Z mosh <kjayanoris@ona.io> # Add modifications to raw tables for Thailand.
+drop_task_constraint [reveal_transaction_tables:events] 2020-11-03T10:26:55Z Wambere <jwambere@ona.io> # Drop the task constraint on events table.

--- a/3-reveal/migrations/7-thai-only/verify/drop_task_constraint.psql
+++ b/3-reveal/migrations/7-thai-only/verify/drop_task_constraint.psql
@@ -1,0 +1,20 @@
+-- Verify thailand_only:drop_task_constraint on pg
+
+BEGIN;
+
+SET search_path TO :"schema",public;
+
+SELECT 1/COUNT(*)
+FROM (
+    SELECT COUNT(*)
+    FROM pg_catalog.pg_constraint
+    WHERE
+    conname = 'fk_events_task'
+    AND conrelid = CONCAT(:'schema', '.events')::regclass
+    AND contype = 'f'
+    AND 1 = ALL(conkey)
+    AND 1 = ALL(confkey)
+) AS foo
+WHERE count = 0;
+
+ROLLBACK;


### PR DESCRIPTION
This is to allow events that are not mapped to tasks such as `Family_Member_Registration` and `Register_Structure` to get into the events table