### PR TITLE
IRS-Lite correct value of percentage sprayed structures

### DIFF
--- a/3-reveal/migrations/8-IRS-Lite/1-Zambia-2020/deploy/update-sprayed-structure.psql
+++ b/3-reveal/migrations/8-IRS-Lite/1-Zambia-2020/deploy/update-sprayed-structure.psql
@@ -1,0 +1,172 @@
+-- Deploy reveal_irs_lite_zambia_202020:update-sprayed-structure to pg
+
+BEGIN;
+
+SET search_path TO :"schema",public;
+
+--
+-- Modify views
+---
+
+-- Add zambia_irs_lite_jurisdictions in pending.
+DROP MATERIALIZED VIEW IF EXISTS pending_:schema .zambia_irs_lite_jurisdictions CASCADE;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS pending_:schema .zambia_irs_lite_jurisdictions
+AS
+SELECT *
+FROM
+(
+    (
+        SELECT DISTINCT ON (jurisdictions_query.jurisdiction_id, plans.identifier)
+            public.uuid_generate_v5(
+                '6ba7b810-9dad-11d1-80b4-00c04fd430c8',
+                concat(jurisdictions_query.jurisdiction_id, plans.identifier)) AS id,
+            plans.identifier as plan_id,
+            jurisdictions_query.jurisdiction_id AS jurisdiction_id,
+            jurisdictions_query.jurisdiction_parent_id AS jurisdiction_parent_id,
+            jurisdictions_query.jurisdiction_name AS jurisdiction_name,
+            jurisdictions_query.jurisdiction_depth AS jurisdiction_depth,
+            jurisdictions_query.jurisdiction_path AS jurisdiction_path,
+            jurisdictions_query.jurisdiction_name_path AS jurisdiction_name_path,
+            jurisdictions_query.totStruct AS totStruct,
+            jurisdictions_query.targStruct AS targStruct,
+            jurisdictions_query.sprayed AS sprayed,
+            jurisdictions_query.found AS found,
+            jurisdictions_query.totAreas AS totAreas,
+            jurisdictions_query.targAreas AS targAreas,
+            jurisdictions_query.visitedAreas AS visitedAreas,
+            jurisdictions_query.sprayCov AS sprayCov,
+            jurisdictions_query.sprayCovTarg AS sprayCovTarg,
+            jurisdictions_query.foundCoverage AS foundCoverage,
+            jurisdictions_query.spraySuccess AS spraySuccess
+        FROM plans
+        LEFT JOIN LATERAL (
+            SELECT
+                zambia_lite_jurisdictions.jurisdiction_id AS jurisdiction_id,
+                COALESCE(zambia_lite_jurisdictions.jurisdiction_parent_id, '') AS jurisdiction_parent_id,
+                zambia_lite_jurisdictions.jurisdiction_name AS jurisdiction_name,
+                zambia_lite_jurisdictions.jurisdiction_geometry AS jurisdiction_geometry,
+                zambia_lite_jurisdictions.jurisdiction_depth AS jurisdiction_depth,
+                zambia_lite_jurisdictions.jurisdiction_path AS jurisdiction_path,
+                zambia_lite_jurisdictions.jurisdiction_name_path AS jurisdiction_name_path,
+                COALESCE(jurisdiction_structure_query.structure, zambia_focus_area_irs_query.totStruct, 0) AS totStruct,
+                COALESCE(jurisdiction_target_query.target, zambia_focus_area_irs_query.targStruct, 0) AS targStruct,
+                zambia_focus_area_irs_query.sprayed AS sprayed,
+                zambia_focus_area_irs_query.found AS found,
+                COALESCE(totAreas_query.totAreas, 0) AS totAreas,
+                zambia_focus_area_irs_query.targAreas AS targAreas,
+                zambia_focus_area_irs_query.visitedAreas AS visitedAreas,
+                CASE
+                    WHEN COALESCE(jurisdiction_structure_query.structure, zambia_focus_area_irs_query.totStruct, 0) = 0 THEN 0
+                    ELSE CAST(zambia_focus_area_irs_query.sprayed AS DECIMAL)/CAST(COALESCE(jurisdiction_structure_query.structure, zambia_focus_area_irs_query.totStruct, 0) AS DECIMAL)
+                END AS sprayCov,
+                CASE
+                    WHEN COALESCE(jurisdiction_target_query.target, zambia_focus_area_irs_query.targStruct, 0) = 0 THEN 0
+                    ELSE CAST(zambia_focus_area_irs_query.sprayed AS DECIMAL)/CAST(COALESCE(jurisdiction_target_query.target, zambia_focus_area_irs_query.targStruct, 0) AS DECIMAL)
+                END AS sprayCovTarg,
+                CASE
+                    WHEN COALESCE(jurisdiction_target_query.target, zambia_focus_area_irs_query.targStruct, 0) = 0 THEN 0
+                    ELSE CAST(zambia_focus_area_irs_query.found AS DECIMAL)/CAST(COALESCE(jurisdiction_target_query.target, zambia_focus_area_irs_query.targStruct, 0) AS DECIMAL)
+                END AS foundCoverage,
+                CASE
+                    WHEN zambia_focus_area_irs_query.found = 0 THEN 0
+                    ELSE CAST(zambia_focus_area_irs_query.sprayed AS DECIMAL)/CAST(zambia_focus_area_irs_query.found AS DECIMAL)
+                END AS spraySuccess
+            FROM jurisdictions_tree AS zambia_lite_jurisdictions
+            LEFT JOIN LATERAL (
+                SELECT
+                    COALESCE(SUM(targAreas), 0) AS targAreas,
+                    COALESCE(SUM(visitedAreas), 0) AS visitedAreas,
+                    COALESCE(SUM(totStruct), 0) AS totStruct,
+                    COALESCE(SUM(targStruct), 0) AS targStruct,
+                    COALESCE(SUM(sprayed), 0) AS sprayed,
+                    COALESCE(SUM(found), 0) AS found
+                FROM zambia_irs_lite_operational_areas AS zirloa
+                WHERE zirloa.plan_id = plans.identifier
+                AND zirloa.jurisdiction_path @> ARRAY[zambia_lite_jurisdictions.jurisdiction_id]
+            ) AS zambia_focus_area_irs_query ON true
+            LEFT JOIN LATERAL (
+                SELECT
+                    COALESCE(COUNT(locations.id) , 0) AS totAreas
+                FROM locations
+                LEFT JOIN jurisdictions_tree
+                    ON jurisdictions_tree.jurisdiction_id = locations.jurisdiction_id
+                WHERE jurisdictions_tree.jurisdiction_path  @> ARRAY[zambia_lite_jurisdictions.jurisdiction_id]
+                AND locations.geographic_level = 4
+            ) AS totAreas_query ON true
+            LEFT JOIN LATERAL (
+                SELECT
+                    key as jurisdiction_id,
+                    COALESCE(data->>'value', '0')::INTEGER as target
+                FROM opensrp_settings
+                WHERE identifier = 'jurisdiction_metadata-target'
+                AND zambia_lite_jurisdictions.jurisdiction_id = opensrp_settings.key
+                ORDER BY COALESCE(data->>'serverVersion', '0')::BIGINT DESC
+                LIMIT 1
+            ) AS jurisdiction_target_query ON true
+            LEFT JOIN LATERAL (
+                SELECT
+                    key as jurisdiction_id,
+                    COALESCE(data->>'value', '0')::INTEGER as structure
+                FROM opensrp_settings
+                WHERE identifier = 'jurisdiction_metadata-structures'
+                AND zambia_lite_jurisdictions.jurisdiction_id = opensrp_settings.key
+                ORDER BY COALESCE(data->>'serverVersion', '0')::BIGINT DESC
+                LIMIT 1
+            ) AS jurisdiction_structure_query ON true
+            WHERE zambia_lite_jurisdictions.is_leaf_node = FALSE
+            AND zambia_focus_area_irs_query.targAreas > 0
+        ) AS jurisdictions_query ON true
+        WHERE plans.intervention_type IN ('IRS-Lite') AND plans.status NOT IN ('draft', 'retired')
+    )
+    UNION (
+        SELECT
+            id,
+            plan_id,
+            jurisdiction_id,
+            jurisdiction_parent_id,
+            jurisdiction_name,
+            jurisdiction_depth,
+            jurisdiction_path,
+            jurisdiction_name_path,
+            totStruct,
+            targStruct,
+            sprayed,
+            found,
+            totAreas,
+            targAreas,
+            visitedAreas,
+            sprayCov,
+            sprayCovTarg,
+            foundCoverage,
+            spraySuccess
+        FROM zambia_irs_lite_operational_areas
+    )
+)
+AS main_query
+ORDER BY main_query.jurisdiction_name;
+
+CREATE INDEX IF NOT EXISTS zambia_irs_lite_jurisdictions_path_idx_gin on pending_:schema .zambia_irs_lite_jurisdictions using GIN(jurisdiction_path);
+CREATE INDEX IF NOT EXISTS zambia_irs_lite_jurisdictions_plan_idx ON pending_:schema .zambia_irs_lite_jurisdictions (plan_id);
+CREATE INDEX IF NOT EXISTS zambia_irs_lite_jurisdictions_jurisdiction_idx ON pending_:schema .zambia_irs_lite_jurisdictions (jurisdiction_id);
+CREATE INDEX IF NOT EXISTS zambia_irs_lite_jurisdictions_jurisdiction_parent_idx ON pending_:schema .zambia_irs_lite_jurisdictions (jurisdiction_parent_id);
+CREATE UNIQUE INDEX IF NOT EXISTS zambia_irs_lite_jurisdictions_idx ON pending_:schema .zambia_irs_lite_jurisdictions (id);
+
+-- Move current views to deprecated_
+ALTER MATERIALIZED VIEW zambia_irs_lite_jurisdictions RENAME TO zambia_irs_lite_jurisdictions_v3;
+
+ALTER INDEX zambia_irs_lite_jurisdictions_path_idx_gin RENAME TO zambia_irs_lite_jurisdictions_path_idx_gin_v3;
+ALTER INDEX zambia_irs_lite_jurisdictions_plan_idx RENAME TO zambia_irs_lite_jurisdictions_plan_idx_v3;
+ALTER INDEX zambia_irs_lite_jurisdictions_jurisdiction_idx RENAME TO zambia_irs_lite_jurisdictions_jurisdiction_idx_v3;
+ALTER INDEX zambia_irs_lite_jurisdictions_jurisdiction_parent_idx RENAME TO zambia_irs_lite_jurisdictions_jurisdiction_parent_idx_v3;
+ALTER INDEX zambia_irs_lite_jurisdictions_idx RENAME TO zambia_irs_lite_jurisdictions_idx_v3;
+
+-- Move views
+
+-- Move current views to deprecated_
+ALTER MATERIALIZED VIEW zambia_irs_lite_jurisdictions_v3 SET SCHEMA deprecated_:schema;
+
+-- Move pending views to current schema
+ALTER MATERIALIZED VIEW pending_:schema .zambia_irs_lite_jurisdictions SET SCHEMA :"schema";
+
+COMMIT;

--- a/3-reveal/migrations/8-IRS-Lite/1-Zambia-2020/revert/update-sprayed-structure.psql
+++ b/3-reveal/migrations/8-IRS-Lite/1-Zambia-2020/revert/update-sprayed-structure.psql
@@ -1,0 +1,19 @@
+-- Revert reveal_irs_lite_zambia_202020:update-sprayed-structure from pg
+
+BEGIN;
+
+SET search_path TO :"schema",public;
+
+ALTER MATERIALIZED VIEW zambia_irs_lite_jurisdictions SET SCHEMA pending_:schema;
+
+ALTER MATERIALIZED VIEW deprecated_:schema .zambia_irs_lite_jurisdictions SET SCHEMA :"schema";
+
+ALTER INDEX zambia_irs_lite_jurisdictions_path_idx_gin_v3 RENAME TO zambia_irs_lite_jurisdictions_path_idx_gin;
+ALTER INDEX zambia_irs_lite_jurisdictions_plan_idx_v3 RENAME TO zambia_irs_lite_jurisdictions_plan_idx;
+ALTER INDEX zambia_irs_lite_jurisdictions_jurisdiction_idx_v3 RENAME TO zambia_irs_lite_jurisdictions_jurisdiction_idx;
+ALTER INDEX zambia_irs_lite_jurisdictions_jurisdiction_parent_idx_v3 RENAME TO zambia_irs_lite_jurisdictions_jurisdiction_parent_idx;
+ALTER INDEX zambia_irs_lite_jurisdictions_idx_v3 RENAME TO zambia_irs_lite_jurisdictions_idx;
+
+DROP MATERIALIZED VIEW pending_:schema .zambia_irs_lite_jurisdictions CASCADE;
+
+COMMIT;

--- a/3-reveal/migrations/8-IRS-Lite/1-Zambia-2020/revert/update-sprayed-structure.psql
+++ b/3-reveal/migrations/8-IRS-Lite/1-Zambia-2020/revert/update-sprayed-structure.psql
@@ -6,7 +6,7 @@ SET search_path TO :"schema",public;
 
 ALTER MATERIALIZED VIEW zambia_irs_lite_jurisdictions SET SCHEMA pending_:schema;
 
-ALTER MATERIALIZED VIEW deprecated_:schema .zambia_irs_lite_jurisdictions SET SCHEMA :"schema";
+ALTER MATERIALIZED VIEW deprecated_:schema .zambia_irs_lite_jurisdictions_v3 SET SCHEMA :"schema";
 
 ALTER INDEX zambia_irs_lite_jurisdictions_path_idx_gin_v3 RENAME TO zambia_irs_lite_jurisdictions_path_idx_gin;
 ALTER INDEX zambia_irs_lite_jurisdictions_plan_idx_v3 RENAME TO zambia_irs_lite_jurisdictions_plan_idx;
@@ -14,6 +14,7 @@ ALTER INDEX zambia_irs_lite_jurisdictions_jurisdiction_idx_v3 RENAME TO zambia_i
 ALTER INDEX zambia_irs_lite_jurisdictions_jurisdiction_parent_idx_v3 RENAME TO zambia_irs_lite_jurisdictions_jurisdiction_parent_idx;
 ALTER INDEX zambia_irs_lite_jurisdictions_idx_v3 RENAME TO zambia_irs_lite_jurisdictions_idx;
 
+ALTER MATERIALIZED VIEW zambia_irs_lite_jurisdictions_v3 RENAME TO zambia_irs_lite_jurisdictions;
 DROP MATERIALIZED VIEW pending_:schema .zambia_irs_lite_jurisdictions CASCADE;
 
 COMMIT;

--- a/3-reveal/migrations/8-IRS-Lite/1-Zambia-2020/sqitch.plan
+++ b/3-reveal/migrations/8-IRS-Lite/1-Zambia-2020/sqitch.plan
@@ -9,3 +9,4 @@ zambia_irs_lite_jurisdictions [reveal_transaction_tables:plans zambia_irs_lite_o
 remove_hard_coded_jurisdiction_depth [reveal_database_views:jurisdictions_tree] 2020-11-06T11:35:51Z mosh <kjayanoris@ona.io> # Remove hard-coded jurisdiction depth.
 update_zambia_irs_lite_structures [zambia_irs_lite_structures] 2020-11-23T11:06:21Z jsmethie <jsmethie@terraframe.com> # Update zambia_lite_structures for RVL-1334.
 update_structure_dependencies 2020-11-28T20:59:49Z jsmethie <jsmethie@terraframe.com> # Update of downstream views to use the updated irs_lite_strucutres view
+update-sprayed-structure 2021-02-16T12:12:21Z Ona,,, <ona@ona-ThinkPad-T470> # Update percentage sprayed structures column

--- a/3-reveal/migrations/8-IRS-Lite/1-Zambia-2020/verify/update-sprayed-structure.psql
+++ b/3-reveal/migrations/8-IRS-Lite/1-Zambia-2020/verify/update-sprayed-structure.psql
@@ -1,0 +1,72 @@
+-- Verify reveal_irs_lite_zambia_202020:update-sprayed-structure on pg
+
+BEGIN;
+
+SET search_path TO :"schema",public;
+
+-- zambia_irs_lite_jurisdictions
+SELECT 1/count(*)
+FROM pg_matviews
+WHERE matviewname = 'zambia_irs_lite_jurisdictions';
+
+SELECT
+    id,
+    plan_id,
+    jurisdiction_id,
+    jurisdiction_parent_id,
+    jurisdiction_name,
+    jurisdiction_depth,
+    jurisdiction_path,
+    jurisdiction_name_path,
+    totStruct,
+    targStruct,
+    sprayed,
+    found,
+    totAreas,
+    targAreas,
+    visitedAreas,
+    sprayCov,
+    sprayCovTarg,
+    foundCoverage,
+    spraySuccess
+FROM zambia_irs_lite_jurisdictions
+WHERE FALSE;
+
+SELECT 1/COUNT(*)
+FROM pg_catalog.pg_indexes
+WHERE
+schemaname = :'schema'
+AND tablename = 'zambia_irs_lite_jurisdictions'
+AND indexdef LIKE '%CREATE UNIQUE INDEX%'
+AND indexname = 'zambia_irs_lite_jurisdictions_idx';
+
+SELECT 1/COUNT(*)
+FROM pg_catalog.pg_indexes
+WHERE
+schemaname = :'schema'
+AND tablename = 'zambia_irs_lite_jurisdictions'
+AND indexdef LIKE '%gin (jurisdiction_path)%'
+AND indexname = 'zambia_irs_lite_jurisdictions_path_idx_gin';
+
+SELECT 1/COUNT(*)
+FROM pg_catalog.pg_indexes
+WHERE
+schemaname = :'schema'
+AND tablename = 'zambia_irs_lite_jurisdictions'
+AND indexname = 'zambia_irs_lite_jurisdictions_plan_idx';
+
+SELECT 1/COUNT(*)
+FROM pg_catalog.pg_indexes
+WHERE
+schemaname = :'schema'
+AND tablename = 'zambia_irs_lite_jurisdictions'
+AND indexname = 'zambia_irs_lite_jurisdictions_jurisdiction_idx';
+
+SELECT 1/COUNT(*)
+FROM pg_catalog.pg_indexes
+WHERE
+schemaname = :'schema'
+AND tablename = 'zambia_irs_lite_jurisdictions'
+AND indexname = 'zambia_irs_lite_jurisdictions_jurisdiction_parent_idx';
+
+ROLLBACK;


### PR DESCRIPTION
Part of https://github.com/onaio/reveal-frontend/issues/1489
The value of percentage sprayed structures was correctly calculated (Sprayed Structures/Total Structure) but wrongly referenced. This PR corrects the wrong referencing.