### PR TITLE
Include missing column to Thai raw clients table

### DIFF
--- a/3-reveal/migrations/7-thai-only/deploy/more_raw_table_modifications.psql
+++ b/3-reveal/migrations/7-thai-only/deploy/more_raw_table_modifications.psql
@@ -1,0 +1,15 @@
+-- Deploy thailand_only:more_raw_table_modifications to pg
+-- requires: reveal_raw_tables:raw_clients
+
+BEGIN;
+
+SET search_path TO :"schema",public;
+
+-- adds archived column to the raw clients table
+ALTER TABLE raw_clients
+ADD COLUMN IF NOT EXISTS archived BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- add indices
+CREATE INDEX IF NOT EXISTS archived_raw_clients_idx ON raw_clients(archived);
+
+COMMIT;

--- a/3-reveal/migrations/7-thai-only/revert/more_raw_table_modifications.psql
+++ b/3-reveal/migrations/7-thai-only/revert/more_raw_table_modifications.psql
@@ -1,0 +1,12 @@
+-- Revert thailand_only:more_raw_table_modifications from pg
+
+BEGIN;
+
+SET search_path TO :"schema",public;
+
+DROP INDEX archived_raw_clients_idx;
+
+ALTER TABLE raw_clients
+DROP COLUMN archived;
+
+COMMIT;

--- a/3-reveal/migrations/7-thai-only/sqitch.plan
+++ b/3-reveal/migrations/7-thai-only/sqitch.plan
@@ -7,3 +7,4 @@ raw_organizations 2020-10-09T06:47:12Z Wambere <jwambere@ona.io> # Create table 
 raw_providers 2020-10-09T06:47:29Z Wambere <jwambere@ona.io> # Create table for raw_providers.
 biophics_columns [opensrp_common_raw_tables:raw_events reveal_raw_tables:raw_clients] 2020-10-09T07:12:14Z Wambere <jwambere@ona.io> # Add extra Biophics columns.
 raw_tables_modifications [reveal_raw_tables:raw_clients opensrp_common_raw_tables:raw_events] 2020-10-10T07:45:25Z mosh <kjayanoris@ona.io> # Add modifications to raw tables for Thailand.
+more_raw_table_modifications [reveal_raw_tables:raw_clients] 2021-03-31T09:41:20Z Ona,,, <ona@ona-ThinkPad-T470> # modify tables for thailand

--- a/3-reveal/migrations/7-thai-only/verify/more_raw_table_modifications.psql
+++ b/3-reveal/migrations/7-thai-only/verify/more_raw_table_modifications.psql
@@ -1,0 +1,13 @@
+-- Verify thailand_only:more_raw_table_modifications on pg
+
+BEGIN;
+
+SET search_path TO :"schema",public;
+
+-- raw clients
+SELECT
+  archived
+FROM raw_clients
+WHERE FALSE;
+
+ROLLBACK;


### PR DESCRIPTION
Adds column `archived` into Thailand raw_clients table.
Part of https://github.com/onaio/canopy/issues/1894