### PR TITLE
Add an auto incrementing column to raw tables

### DIFF
--- a/3-reveal/migrations/1-raw_tables/deploy/add_serial_id.psql
+++ b/3-reveal/migrations/1-raw_tables/deploy/add_serial_id.psql
@@ -1,0 +1,23 @@
+-- Deploy reveal_raw_tables:add_serial_id to pg
+
+BEGIN;
+
+SET search_path TO :"schema",public;
+
+-- Add serial_id column - auto incrementing column.
+
+ALTER TABLE raw_clients ADD COLUMN IF NOT EXISTS serial_id SERIAL;
+
+ALTER TABLE raw_jurisdictions ADD COLUMN IF NOT EXISTS serial_id SERIAL;
+
+ALTER TABLE raw_locations ADD COLUMN IF NOT EXISTS serial_id SERIAL;
+
+ALTER TABLE raw_plans ADD COLUMN IF NOT EXISTS serial_id SERIAL;
+
+ALTER TABLE raw_settings ADD COLUMN IF NOT EXISTS serial_id SERIAL;
+
+ALTER TABLE raw_tasks ADD COLUMN IF NOT EXISTS serial_id SERIAL;
+
+ALTER TABLE raw_events ADD COLUMN IF NOT EXISTS serial_id SERIAL;
+
+COMMIT;

--- a/3-reveal/migrations/1-raw_tables/revert/add_serial_id.psql
+++ b/3-reveal/migrations/1-raw_tables/revert/add_serial_id.psql
@@ -1,0 +1,28 @@
+-- Revert reveal_raw_tables:add_serial_id from pg
+
+BEGIN;
+ 
+SET search_path TO :"schema",public;
+
+ALTER TABLE raw_clients
+DROP COLUMN serial_id;
+
+ALTER TABLE raw_jurisdictions
+DROP COLUMN serial_id;
+
+ALTER TABLE raw_locations
+DROP COLUMN serial_id;
+
+ALTER TABLE raw_plans
+DROP COLUMN serial_id;
+
+ALTER TABLE raw_settings
+DROP COLUMN serial_id;
+
+ALTER TABLE raw_tasks
+DROP COLUMN serial_id;
+
+ALTER TABLE raw_events
+DROP COLUMN serial_id;
+
+COMMIT;

--- a/3-reveal/migrations/1-raw_tables/sqitch.plan
+++ b/3-reveal/migrations/1-raw_tables/sqitch.plan
@@ -10,3 +10,4 @@ raw_clients [raw_locations] 2020-08-06T14:04:56Z Wambere <wambere@ona.io> # Crea
 raw_settings [raw_clients] 2020-08-17T08:31:07Z Wambere <wambere@ona.io> # Creates table for raw_settings.
 sync_column [opensrp_common_raw_tables:raw_events raw_settings] 2020-09-11T12:30:24Z Wambere <wambere@ona.io> # Add sync column to raw data tables.
 drop_length_constraints 2020-10-05T13:12:23Z mosh <kjayanoris@ona.io> # Drop length constraints.
+add_serial_id 2022-01-03T08:41:12Z Ona,,, <ona@ona-ThinkPad-T470> # Add auto incrementing field.

--- a/3-reveal/migrations/1-raw_tables/verify/add_serial_id.psql
+++ b/3-reveal/migrations/1-raw_tables/verify/add_serial_id.psql
@@ -1,0 +1,50 @@
+-- Verify reveal_raw_tables:add_serial_id on pg
+
+BEGIN;
+
+SET search_path TO :"schema",public;
+
+-- clients
+SELECT
+    serial_id
+FROM raw_clients
+WHERE FALSE;
+
+-- jurisdictions
+SELECT
+    serial_id
+FROM raw_jurisdictions
+WHERE FALSE;
+
+-- locations
+SELECT
+    serial_id
+FROM raw_locations
+WHERE FALSE;
+
+-- plans
+SELECT
+    serial_id
+FROM raw_plans
+WHERE FALSE;
+
+-- settings
+SELECT
+    serial_id
+FROM raw_settings
+WHERE FALSE;
+
+-- tasks
+SELECT
+    serial_id
+FROM raw_tasks
+WHERE FALSE;
+
+-- events
+SELECT
+    serial_id
+FROM raw_events
+WHERE FALSE;
+
+
+ROLLBACK;


### PR DESCRIPTION
Part of https://github.com/onaio/canopy/issues/2548

Adds an a new auto incrementing column (`serial_id`) to all raw tables